### PR TITLE
Bug where passwords cleared in DB

### DIFF
--- a/webapp/routes/socket.js
+++ b/webapp/routes/socket.js
@@ -23,16 +23,18 @@ module.exports = function(socket) {
                     console.log(err);
                     return;
                 }
+                var password = currentUser.password;
                 currentUser.password = null;
-                socket.emit('hasBeenMatched', {user: JSON.stringify(currentUser)})
+                socket.emit('hasBeenMatched', {user: JSON.stringify(currentUser)});
+                currentUser.password = password;
             });
 
         });
 
         User.find({email: {'$ne': data.userEmail }, wantsToBeMatched: true}, function(error, users){
             if(error || users.length == 0){
-                //bleh
-                return
+                //If no matching user found
+                return;
             }
 
             var userToMatch = users[0];
@@ -47,21 +49,24 @@ module.exports = function(socket) {
                 if(err) {
                     console.log('Could not save user: ' + userToMatch);
                     console.log(err);
-                    return;
+                    //return; //redundant because nothing else after
                 }
             });
             currentUser.save(function(err) {
                 if(err) {
                     console.log('Could not save user' + currentUser);
                     console.log(err);
-                    return;
+                    //return; //redundant because nothing else after
                 }
             });
-
+            var matchPassword = userToMatch.password;
+            var currPassword = currentUser.password;
             userToMatch.password = null;
             currentUser.password = null;
             socket.broadcast.emit('matched' + userToMatch.email, {user: JSON.stringify(userToMatch)});
             socket.emit('matched' + currentUser.email, {user: JSON.stringify(currentUser)});
+            userToMatch.password = matchPassword;
+            currentUser.password = currPassword;
 
         });
     })


### PR DESCRIPTION
There was a bug where if you wanted to be matched, or got matched and
logged out your password would be cleared in the database. I found the
bug on the logout branch but fixed it separately here. It occurs when
the passwords are null'd. For whatever reason when a user logs out they
get updated in the DB and since their password got assigned to null it
gets wiped. Now fixed.

Also cleaned the file with errors webstorm was showing.
